### PR TITLE
Hardcode boto3 client region in us-west-2

### DIFF
--- a/export.py
+++ b/export.py
@@ -203,7 +203,7 @@ if __name__ == '__main__':
 	else:
 		logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(name)s: %(message)s')
 
-	client = boto3.client('discovery')
+	client = boto3.client('discovery', region_name='us-west-2') #setting us-west-2 as it is the only region where the service is available
 
 	logging.info(str.format("Querying Discovery Service for agents to export. directory={}, start_time={}, end_time={}, filters={}", dir_name, start_input, end_input, filters))
 	agents_queue = []


### PR DESCRIPTION
As the service is only available in us-west-2, I suggest to hardcode the region_name in the boto3 connection string. This way, it doesn't conflict with the default region set on the computer.
The alternative would be to add an argument named region with a default value of us-west-2?